### PR TITLE
UUIDCounter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN=events_counter
 
 SRCS_SFLOW_$(WITH_SFLOW) += sflow_collect.c
 SRCS= src/main.cpp version.cpp src/UUIDCountersDB/UUIDCountersDB.cpp \
-	src/UUIDConsumer/UUIDConsumerKafka.cpp
+	src/UUIDConsumer/UUIDConsumerKafka.cpp src/UUIDCounter/UUIDCounter.cpp
 OBJS= $(SRCS:.cpp=.o)
 
 TESTS_C = $(wildcard tests/0*.cpp)

--- a/configure.events-counter
+++ b/configure.events-counter
@@ -20,6 +20,12 @@ mkl_mkvar_append CPPFLAGS CPPFLAGS "-Wdisabled-optimization -Wshadow"
 mkl_mkvar_append CPPFLAGS CPPFLAGS "-Wcast-qual -Wunused -Wextra"
 mkl_mkvar_append CPPFLAGS CPPFLAGS "-I. -I./src"
 
+function checks_libpthread {
+    mkl_lib_check pthread HAVE_LIBPTHREAD fail CC "-lpthread" \
+      "#include <pthread.h>
+       void *f();void *f(){return pthread_mutex_init;}"
+}
+
 function checks_librdkafka {
     # Check that librdkafka is available, and allow to link it statically.
     mkl_meta_set "librdkafka" "desc" "librdkafka is available at http://github.com/edenhill/librdkafka."
@@ -32,4 +38,5 @@ function checks {
     mkl_define_set "OS name" "osName" "`uname`"
 
     checks_librdkafka
+    checks_libpthread
 }

--- a/src/UUIDCounter/UUIDCounter.cpp
+++ b/src/UUIDCounter/UUIDCounter.cpp
@@ -1,0 +1,28 @@
+#include "UUIDCounter.h"
+
+#include <map>
+
+using namespace std;
+using namespace EventsCounter;
+
+void UUIDCounter::run(UUIDCounter *instance, UUIDConsumer *consumer) {
+	unique_ptr<UUIDConsumer> consumer_ptr(consumer);
+
+	while (instance->running.load()) {
+		UUIDBytes data = consumer_ptr->consume(1000);
+		lock_guard<mutex> lock(instance->mtx);
+		instance->uuid_counters_db->uuid_increment(data.get_uuid(), 1);
+	}
+}
+
+UUIDCounter::~UUIDCounter() {
+	this->running.store(false);
+}
+
+UUIDCountersDB *UUIDCounter::swap_counter(UUIDCountersDB *_uuid_counters_db) {
+	lock_guard<mutex> lock(this->mtx);
+	UUIDCountersDB *tmp_db = this->uuid_counters_db;
+	this->uuid_counters_db = _uuid_counters_db;
+
+	return tmp_db;
+}

--- a/src/UUIDCounter/UUIDCounter.h
+++ b/src/UUIDCounter/UUIDCounter.h
@@ -1,0 +1,49 @@
+#ifndef COUNTER_H
+#define COUNTER_H
+
+#include "../UUIDConsumer/UUIDConsumer.h"
+#include "../UUIDCountersDB/UUIDCountersDB.h"
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+
+namespace EventsCounter {
+
+class UUIDCounter {
+private:
+	UUIDConsumer *consumer;
+	UUIDCountersDB *uuid_counters_db;
+	std::mutex mtx;
+	std::atomic<bool> running{true};
+	std::thread worker{run, this, consumer};
+
+	static void run(UUIDCounter *instance, UUIDConsumer *consumer);
+
+public:
+	/**
+	 *
+	 */
+	UUIDCounter(UUIDConsumer *_consumer, UUIDCountersDB *_uuid_counters_db)
+	    : consumer(_consumer), uuid_counters_db(_uuid_counters_db) {
+	}
+
+	/**
+	 *
+	 */
+	~UUIDCounter();
+
+	/**
+	 *
+	 */
+	UUIDCounter &operator=(const UUIDCounter &) = delete;
+
+	/**
+	 * [swap_counter description]
+	 * @param  counter_db [description]
+	 * @return            [description]
+	 */
+	UUIDCountersDB *swap_counter(UUIDCountersDB *counter_db);
+};
+};
+#endif /* COUNTER_H */


### PR DESCRIPTION
Add a counter modules.

**Private**:

- [x] `void UUIDCounter::run(UUIDCounter *instance, UUIDConsumer *consumer)`: Consume messages in its own thread.

**Public**:

- [x] `swap_counters(UUIDCountersDB *)`: Wrapper for `swap_counters` of the inner `UUIDCountersDB` class.

---
Closes #1 