### PR TITLE
UUIDConsumerKafka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ include Makefile.config
 BIN=events_counter
 
 SRCS_SFLOW_$(WITH_SFLOW) += sflow_collect.c
-SRCS= src/main.cpp version.cpp src/UUIDCountersDB/UUIDCountersDB.cpp
+SRCS= src/main.cpp version.cpp src/UUIDCountersDB/UUIDCountersDB.cpp \
+	src/UUIDConsumer/UUIDConsumerKafka.cpp
 OBJS= $(SRCS:.cpp=.o)
 
 TESTS_C = $(wildcard tests/0*.cpp)

--- a/src/UUIDConsumer/UUIDBytes.h
+++ b/src/UUIDConsumer/UUIDBytes.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace EventsCounter {
+
+class UUIDBytes {
+private:
+	std::pair<std::string, uint64_t> pair;
+	bool is_empty;
+
+public:
+	/**
+	 *
+	 */
+	UUIDBytes(std::string uuid, uint64_t bytes)
+	    : pair(uuid, bytes), is_empty(false) {
+	}
+
+	/**
+	 *
+	 */
+	UUIDBytes() : is_empty(true) {
+	}
+
+	/**
+	 * [get_uuid description]
+	 * @return [description]
+	 */
+	const std::string &get_uuid() const {
+		return this->pair.first;
+	}
+
+	/**
+	 * [get_bytes description]
+	 * @return [description]
+	 */
+	uint64_t get_bytes() const {
+		return this->pair.second;
+	}
+
+	/**
+	 * [empty description]
+	 * @return [description]
+	 */
+	bool empty() const {
+		return this->is_empty;
+	}
+};
+};

--- a/src/UUIDConsumer/UUIDConsumer.h
+++ b/src/UUIDConsumer/UUIDConsumer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "UUIDBytes.h"
+
+#include <string>
+namespace EventsCounter {
+
+class UUIDConsumer {
+private:
+public:
+	/**
+	 *
+	 */
+	virtual ~UUIDConsumer() = 0;
+
+	/**
+	 * [consume description]
+	 * @param  timeout [description]
+	 * @return         [description]
+	 */
+	virtual UUIDBytes consume(uint32_t timeout) const = 0;
+};
+};

--- a/src/UUIDConsumer/UUIDConsumerKafka.cpp
+++ b/src/UUIDConsumer/UUIDConsumerKafka.cpp
@@ -1,0 +1,97 @@
+#include <iostream>
+#include <memory>
+
+#include "UUIDConsumer.h"
+#include "UUIDConsumerKafka.h"
+
+using namespace rapidjson;
+using namespace std;
+using namespace EventsCounter;
+
+UUIDBytes UUIDConsumerKafka::consume(uint32_t timeout) const {
+	unique_ptr<RdKafka::Message> message(
+			this->kafka_consumer->consume(timeout));
+
+	switch (message->err()) {
+	case RdKafka::ERR__TIMED_OUT:
+		break;
+
+	case RdKafka::ERR__PARTITION_EOF:
+		break;
+
+	case RdKafka::ERR_NO_ERROR: {
+		const char *buf = (const char *)message->payload();
+		Document json;
+		json.Parse(buf);
+
+		if (!json.IsObject() || !json.HasMember("sensor_uuid") ||
+		    !json["sensor_uuid"].IsString()) {
+			break;
+		}
+
+		Value &uuid = json["sensor_uuid"];
+		std::string uuid_str = uuid.GetString();
+
+		return UUIDBytes(uuid_str, message->len());
+	}
+
+	default:
+		break;
+	}
+
+	return UUIDBytes();
+}
+
+UUIDConsumerKafka::UUIDConsumerKafka(const char *brokers,
+				     const char *group_id,
+				     const char *topic) {
+	std::string errstr;
+	std::vector<std::string> topics;
+
+	topics.push_back(topic);
+
+	unique_ptr<RdKafka::Conf> conf(
+			RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
+	unique_ptr<RdKafka::Conf> tconf(
+			RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC));
+
+	if (conf->set("group.id", group_id, errstr) != RdKafka::Conf::CONF_OK) {
+		throw "Error setting group id";
+	}
+
+	if (conf->set("metadata.broker.list", brokers, errstr) !=
+	    RdKafka::Conf::CONF_OK) {
+		throw "Error setting broker list";
+	}
+
+	if (tconf->set("offset.store.method", "broker", errstr) !=
+	    RdKafka::Conf::CONF_OK) {
+		throw "Error setting group id";
+	}
+
+	if (tconf->set("auto.offset.reset", "smallest", errstr) !=
+	    RdKafka::Conf::CONF_OK) {
+		throw "Error setting offset";
+	}
+
+	if (conf->set("default_topic_conf", tconf.get(), errstr) !=
+	    RdKafka::Conf::CONF_OK) {
+		throw "Error setting topic conf";
+	}
+
+	this->kafka_consumer =
+			RdKafka::KafkaConsumer::create(conf.get(), errstr);
+	if (!this->kafka_consumer) {
+		throw "Failed to create consumer";
+	}
+
+	RdKafka::ErrorCode err = this->kafka_consumer->subscribe(topics);
+	if (err) {
+		throw "Failed to subscribe to topic";
+	}
+}
+
+UUIDConsumerKafka::~UUIDConsumerKafka() {
+	this->kafka_consumer->close();
+	delete this->kafka_consumer;
+}

--- a/src/UUIDConsumer/UUIDConsumerKafka.h
+++ b/src/UUIDConsumer/UUIDConsumerKafka.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "UUIDBytes.h"
+
+#include <librdkafka/rdkafkacpp.h>
+#include <rapidjson/document.h>
+
+namespace EventsCounter {
+
+class UUIDConsumerKafka {
+private:
+	RdKafka::KafkaConsumer *kafka_consumer;
+
+public:
+	/**
+	 *
+	 */
+	UUIDConsumerKafka(const char *brokers,
+			  const char *group_id,
+			  const char *topic);
+
+	/**
+	 *
+	 */
+	UUIDConsumerKafka(RdKafka::Conf *t_kafka_consumer_conf,
+			  RdKafka::Conf *t_kafka_topic_conf);
+
+	/**
+	 *
+	 */
+	UUIDConsumerKafka(RdKafka::KafkaConsumer *t_kafka_consumer)
+	    : kafka_consumer(t_kafka_consumer) {
+	}
+
+	/**
+	 *
+	 */
+	~UUIDConsumerKafka();
+
+	/**
+	 *
+	 */
+	UUIDConsumerKafka &operator=(const UUIDConsumerKafka &) = delete;
+
+	/**
+	 * [consume description]
+	 * @param  timeout [description]
+	 * @return         [description]
+	 */
+	UUIDBytes consume(uint32_t timeout) const;
+};
+};

--- a/tests/0001-UUIDConsumer.cpp
+++ b/tests/0001-UUIDConsumer.cpp
@@ -1,0 +1,90 @@
+#include "../src/UUIDConsumer/UUIDConsumerKafka.h"
+#include "../src/UUIDCountersDB/UUIDCountersDB.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace {
+
+using namespace std;
+using namespace EventsCounter;
+
+static char *rand_tmpl() {
+	char *tmpl = strdup("rb_flow_XXXXXX");
+	int fd = mkstemp(tmpl);
+	close(fd);
+	remove(tmpl);
+
+	return tmpl;
+}
+
+class UUIDConsumerTest : public ::testing::Test {
+protected:
+	void UUIDProduce(const char *uuid, const char *topic_str) {
+		char *message = (char *)calloc(128, sizeof(char));
+		sprintf(message, "{\"sensor_uuid\": \"%s\"}", uuid);
+
+		string errstr;
+		RdKafka::Conf *conf = RdKafka::Conf::create(
+				RdKafka::Conf::CONF_GLOBAL);
+		RdKafka::Conf *tconf = RdKafka::Conf::create(
+				RdKafka::Conf::CONF_TOPIC);
+
+		conf->set("metadata.broker.list", "localhost:9092", errstr);
+
+		RdKafka::Producer *producer =
+				RdKafka::Producer::create(conf, errstr);
+		if (!producer) {
+			std::cerr << "Failed to create producer: " << errstr
+				  << std::endl;
+		}
+
+		RdKafka::Topic *topic = RdKafka::Topic::create(
+				producer, topic_str, tconf, errstr);
+		if (!topic) {
+			std::cerr << "Failed to create topic: " << errstr
+				  << std::endl;
+		}
+
+		producer->produce(topic,
+				  0,
+				  RdKafka::Producer::RK_MSG_COPY,
+				  message,
+				  strlen(message),
+				  NULL,
+				  NULL);
+		free(message);
+	}
+};
+
+TEST_F(UUIDConsumerTest, consumer_uuid) {
+	EXPECT_NO_THROW({
+		UUIDBytes data;
+		char *topic_str = rand_tmpl();
+		char *group_id = rand_tmpl();
+
+		unique_ptr<UUIDConsumerKafka> consumer(new UUIDConsumerKafka(
+				"localhost:9092", group_id, topic_str));
+
+		UUIDProduce("123456", topic_str);
+		while (true) {
+			data = consumer->consume(100);
+			if (!data.empty()) {
+				break;
+			}
+		}
+
+		free(group_id);
+		free(topic_str);
+		EXPECT_EQ("123456", data.get_uuid());
+		EXPECT_EQ(25, data.get_bytes());
+	});
+}
+}
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
**Private**:

- [x] `RdKafka::KafkaConsumer`

**Public**

- [x] `std::string consume()`

---

Closes #10 